### PR TITLE
removed height from textarea styling

### DIFF
--- a/src/editor/app-bar/dialogs/ModelSchemaDialog.tsx
+++ b/src/editor/app-bar/dialogs/ModelSchemaDialog.tsx
@@ -16,7 +16,6 @@ import { setModelSchema } from '../../../reducers';
 const styles: StyleRulesCallback<'textarea'> = () => ({
   textarea: {
     width: 400,
-    height: 600,
     whiteSpace: 'pre-wrap',
     overflowWrap: 'normal',
     overflowX: 'scroll'


### PR DESCRIPTION
We don't need to set height, this cause problems for small screens. Our dialog is already scrollable